### PR TITLE
Enable software flow offloading by default for decrease CPU load and NAT improvement

### DIFF
--- a/package/network/config/firewall/files/firewall.config
+++ b/package/network/config/firewall/files/firewall.config
@@ -3,6 +3,7 @@ config defaults
 	option input		ACCEPT
 	option output		ACCEPT
 	option forward		REJECT
+	option flow_offloading  1
 # Uncomment this line to disable ipv6 rules
 #	option disable_ipv6	1
 


### PR DESCRIPTION
We need to set 'flow_offloading" default to 1 in firewall setting. This is new feature in openwrt which is used for decrease CPU load and increase routing throughput. So we will observe more throughput with this feature.