### PR TITLE
Bnx 136 SIM connection reset durin insert/remove

### DIFF
--- a/package/network/utils/comgt/Makefile
+++ b/package/network/utils/comgt/Makefile
@@ -79,6 +79,8 @@ define Package/comgt/install
 	$(INSTALL_DATA) ./files/getcarrier.gcom $(1)/etc/gcom/getcarrier.gcom
 	$(INSTALL_DATA) ./files/getcnum.gcom $(1)/etc/gcom/getcnum.gcom
 	$(INSTALL_DATA) ./files/getimsi.gcom $(1)/etc/gcom/getimsi.gcom
+	$(INSTALL_DATA) ./files/powercycle.gcom $(1)/etc/gcom/powercycle.gcom
+	$(INSTALL_DATA) ./files/simdetect.gcom $(1)/etc/gcom/simdetect.gcom
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/tty
 	$(INSTALL_CONF) ./files/3g.usb $(1)/etc/hotplug.d/tty/30-3g
 	$(INSTALL_DIR) $(1)/lib/netifd/proto

--- a/package/network/utils/comgt/files/powercycle.gcom
+++ b/package/network/utils/comgt/files/powercycle.gcom
@@ -1,0 +1,19 @@
+opengt
+ set com 115200n81
+ set comecho off
+ set senddelay 0.02
+ waitquiet 0.2 0.2
+ flash 0.1
+
+:start
+ send "AT+CFUN=0^m"
+ get 1 "" $s
+ print $s
+ send "AT+CFUN=1,1^m"
+ get 1 "" $s
+ print $s
+
+:continue
+ exit 0
+
+

--- a/package/network/utils/comgt/files/simdetect.gcom
+++ b/package/network/utils/comgt/files/simdetect.gcom
@@ -1,0 +1,16 @@
+opengt
+ set com 115200n81
+ set comecho off
+ set senddelay 0.02
+ waitquiet 0.2 0.2
+ flash 0.1
+
+:start
+ send "AT+CPIN?^m"
+ get 1 "" $s
+ print $s
+
+:continue
+ exit 0
+
+


### PR DESCRIPTION
SIM connection is not working when we insert/remove sim after device bootsup.
Need to reset SIM pci from interface restart button so it will detect sim and able to make connection.
